### PR TITLE
DEVOPS-14741 add release workflow, fix CODEOWNERS and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 10
     cooldown:
       default-days: 7
     groups:
@@ -18,3 +19,13 @@ updates:
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
+        with:
+          generate_release_notes: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
-* @actions/actions-runtime
+* @AnchorFree/kyiv-devops
+.github/dependabot.yml @AnchorFree/secops
+.github/workflows/codeql-analysis.yml @AnchorFree/secops


### PR DESCRIPTION
- Replace placeholder CODEOWNERS (`@actions/actions-runtime` from upstream template) with `@AnchorFree/kyiv-devops`; route dependabot.yml and codeql-analysis.yml to `@AnchorFree/secops`.
- Bring npm dependabot block to parity with github-actions: add cooldown, grouped minor/patch updates, and `open-pull-requests-limit`.
- Add minimal release workflow triggered on `vX.Y.Z` tag push that creates a GitHub Release with auto-generated notes. Compatible with org-level policy requiring actions to be pinned to commit SHAs.